### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "homepage": "https://github.com/Roave/psr-container-doctrine",
     "require": {
-        "php": "~8.2.0 || ~8.3.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "doctrine/annotations": "^1.14.3 || ^2.0.1",
         "doctrine/cache": "^2.2",
         "doctrine/common": "^3.4.3",


### PR DESCRIPTION
Since Doctrine ORM 2.18 supports PHP 8.4, it would be beneficial to add PHP 8.4 support to version 4.2.